### PR TITLE
Add cluster_id output

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,4 +212,4 @@ resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres96_parameter_
 | cluster_endpoint | The 'writer' endpoint for the cluster |
 | reader_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 | cluster_arn | ARN of the cluster, useful when defining centralised backup script |
-
+| cluster_id | ID of the cluster, useful to any resources requiring cluster's ID, e.g. rds_cluster_role_association |

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "reader_endpoint" {
 output "cluster_arn" {
   value = "${aws_rds_cluster.default.arn}"
 }
+
+// Cluster ID - useful to any resources requiring cluster's ID, e.g. rds_cluster_role_association
+output "cluster_id" {
+  value = "${aws_rds_cluster.default.id}"
+}


### PR DESCRIPTION
TF has recently added ability to attach a "role+feature" to an RDS cluster. Exporting the cluster's id helps other resources requiring it: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_role_association